### PR TITLE
Removed logback references in spring-boot README

### DIFF
--- a/java/spring-boot/README.md
+++ b/java/spring-boot/README.md
@@ -12,8 +12,3 @@ proper value):
 Now, visit `http://localhost:8080/` in your browser and a `WARN` and
 `ERROR` message should be sent to the Sentry server you point to in your 
 `SENTRY_DSN`.
-
-See [src/main/resources/logback.xml](https://github.com/getsentry/examples/blob/master/java/spring/src/main/resources/logback.xml)
-for example logger configuration and
-[pom.xml](https://github.com/getsentry/examples/blob/master/java/spring/pom.xml)
-for the dependency on `io.sentry:sentry-logback`.


### PR DESCRIPTION
The references in the README to the logback.xml configuration file and sentry-logback dependency in pom.xml were obsolete in this spring-boot example.