### PR TITLE
fix(gcf): add trailing list bracket to examples

### DIFF
--- a/gcp-cloud-functions/python/README.md
+++ b/gcp-cloud-functions/python/README.md
@@ -6,24 +6,24 @@
 
  - Create development package from the source code
  - Upload the file into the GCP Cloud console
- - Refer usage for use case specific handling 
+ - Refer usage for use case specific handling
 
 
-## Create a development package 
+## Create a development package
 
 ##### 1. Clone the git repo on your development machine
 
-##### 2. Cloned repo contains multiple folders, each of these folder contains an example of how we can capture errors/exceptions on sentry dashboard 
+##### 2. Cloned repo contains multiple folders, each of these folder contains an example of how we can capture errors/exceptions on sentry dashboard
 
-##### 3. Go to any folder and edit the python source file. Edit below section of the file where you replace 'dsn' with your own DSN. 
+##### 3. Go to any folder and edit the python source file. Edit below section of the file where you replace 'dsn' with your own DSN.
 ```
 sentry_sdk.init(
     dsn="<your DSN>",
-    integrations=GcpIntegration()]
+    integrations=[GcpIntegration()],
 )
 ```
 
-##### 4. Zip the contents of the folder so that it can be uploaded to cloud function. 
+##### 4. Zip the contents of the folder so that it can be uploaded to cloud function.
 ```html
 $zip -r filename.zip *
 ```
@@ -61,7 +61,7 @@ b) Timeout : 1 min
 This function contains code that instruments the network error using different scenarios.
 
 >**Scenario: Wrong IP address**
- 
+
 In this scenario, we put the wrong IP address.
 
 ##### Configuration: Set the following parameters in cloud function dashboard for wrong IP address scenario:
@@ -72,13 +72,13 @@ b) Timeout : 2 min 30 sec
 ```
 
 >**Scenario: Wrong PORT number**
- 
+
 In this scenario, we put the wrong PORT number.
 
 ##### Configuration: Set the following parameters in cloud function dashboard for wrong PORT number scenario:
 
 ```html
-a) Function to execute : cloud_handler 
+a) Function to execute : cloud_handler
 b) Timeout : 2 min 30 sec
 ```
 

--- a/gcp-cloud-functions/python/custom_tag_and_context/main.py
+++ b/gcp-cloud-functions/python/custom_tag_and_context/main.py
@@ -16,7 +16,7 @@ import os
 # Configure Sentry SDK
 sentry_sdk.init(
     dsn="<your DSN>",
-    integrations=GcpIntegration()]
+    integrations=[GcpIntegration()],
 )
 
 # Fetching value of Environment variable set in Lambda function

--- a/gcp-cloud-functions/python/handled_exception/main.py
+++ b/gcp-cloud-functions/python/handled_exception/main.py
@@ -12,7 +12,7 @@ from sentry_sdk.integrations.gcp import GcpIntegration
 # Configure Sentry SDK
 sentry_sdk.init(
     dsn="<your DSN>",
-    integrations=GcpIntegration()]
+    integrations=[GcpIntegration()],
 )
 
 def cloud_handler(event, context):

--- a/gcp-cloud-functions/python/network_error_wrong_address/main.py
+++ b/gcp-cloud-functions/python/network_error_wrong_address/main.py
@@ -15,7 +15,7 @@ from sentry_sdk.integrations.gcp import GcpIntegration
 # Configure Sentry SDK
 sentry_sdk.init(
     dsn="<your DSN>",
-    integrations=GcpIntegration()]
+    integrations=[GcpIntegration()],
 )
 
 # Constants

--- a/gcp-cloud-functions/python/network_error_wrong_port/main.py
+++ b/gcp-cloud-functions/python/network_error_wrong_port/main.py
@@ -16,7 +16,7 @@ from sentry_sdk.integrations.gcp import GcpIntegration
 # Configure Sentry SDK
 sentry_sdk.init(
     dsn="<your DSN>",
-    integrations=GcpIntegration()]
+    integrations=[GcpIntegration()],
 )
 
 # Constants
@@ -37,7 +37,7 @@ def cloud_handler(event, context):
     headers = {}
 
     url = CORRECT_URL + ":" + WRONG_PORT + API
-    
+
     response = get_call_api(url, payload, headers)
     response_code = response.status_code
     try:

--- a/gcp-cloud-functions/python/unhandled_exception/main.py
+++ b/gcp-cloud-functions/python/unhandled_exception/main.py
@@ -12,7 +12,7 @@ from sentry_sdk.integrations.gcp import GcpIntegration
 # Configure Sentry SDK
 sentry_sdk.init(
     dsn="<your DSN>",
-    integrations=GcpIntegration()]
+    integrations=[GcpIntegration()],
 )
 
 def cloud_handler(event, context):


### PR DESCRIPTION
`integrations=GcpIntegration()]` is invalid syntax. I also added a trailing comma since most prefer that.

Also sorry for the messy diff, my editor trims unnecessary trailing whitespace.

Oh, I also see we have the pubsub entrypoint signatures here too. Would the changes from https://github.com/getsentry/sentry-docs/pull/2123 be desirable as well?