### PR TITLE
ASP.NET classic on Sentry .NET 3.0

### DIFF
--- a/dotnet/AspNetMvc5Ef6/AspNetMvc5Ef6.csproj
+++ b/dotnet/AspNetMvc5Ef6/AspNetMvc5Ef6.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="packages\EntityFramework.6.4.4\build\EntityFramework.props" Condition="Exists('packages\EntityFramework.6.4.4\build\EntityFramework.props')" />
   <Import Project="packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.8\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.8\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
   <Import Project="packages\Microsoft.Net.Compilers.2.6.1\build\Microsoft.Net.Compilers.props" Condition="Exists('packages\Microsoft.Net.Compilers.2.6.1\build\Microsoft.Net.Compilers.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -46,32 +47,60 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>packages\EntityFramework.6.4.4\lib\net45\EntityFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>packages\EntityFramework.6.4.4\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.Bcl.AsyncInterfaces.5.0.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Sentry, Version=1.1.0.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0, processorArchitecture=MSIL">
-      <HintPath>packages\Sentry.1.1.0\lib\net461\Sentry.dll</HintPath>
+    <Reference Include="Sentry, Version=3.0.0.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0, processorArchitecture=MSIL">
+      <HintPath>packages\Sentry.3.0.0-alpha.7\lib\net461\Sentry.dll</HintPath>
     </Reference>
-    <Reference Include="Sentry.EntityFramework, Version=1.0.0.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0, processorArchitecture=MSIL">
-      <HintPath>packages\Sentry.EntityFramework.1.0.0\lib\net461\Sentry.EntityFramework.dll</HintPath>
+    <Reference Include="Sentry.AspNet, Version=3.0.0.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0, processorArchitecture=MSIL">
+      <HintPath>packages\Sentry.AspNet.3.0.0-alpha.7\lib\net461\Sentry.AspNet.dll</HintPath>
     </Reference>
-    <Reference Include="Sentry.PlatformAbstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0, processorArchitecture=MSIL">
-      <HintPath>packages\Sentry.PlatformAbstractions.1.0.0\lib\net45\Sentry.PlatformAbstractions.dll</HintPath>
-    </Reference>
-    <Reference Include="Sentry.Protocol, Version=1.0.2.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0, processorArchitecture=MSIL">
-      <HintPath>packages\Sentry.Protocol.1.0.2\lib\net46\Sentry.Protocol.dll</HintPath>
+    <Reference Include="Sentry.EntityFramework, Version=2.1.6.0, Culture=neutral, PublicKeyToken=fba2ec45388e2af0, processorArchitecture=MSIL">
+      <HintPath>packages\Sentry.EntityFramework.2.1.6\lib\net461\Sentry.EntityFramework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>packages\System.Runtime.CompilerServices.Unsafe.5.0.0\lib\net45\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
       <Private>True</Private>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Text.Encodings.Web, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Text.Encodings.Web.5.0.0\lib\net461\System.Text.Encodings.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Json, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Text.Json.5.0.0\lib\net461\System.Text.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
@@ -137,12 +166,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="EntityFramework">
-      <HintPath>packages\EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>
-    </Reference>
-    <Reference Include="EntityFramework.SqlServer">
-      <HintPath>packages\EntityFramework.6.2.0\lib\net45\EntityFramework.SqlServer.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.AspNet.Identity.Core">
       <HintPath>packages\Microsoft.AspNet.Identity.Core.2.2.1\lib\net45\Microsoft.AspNet.Identity.Core.dll</HintPath>
     </Reference>
@@ -274,7 +297,10 @@
     </PropertyGroup>
     <Error Condition="!Exists('packages\Microsoft.Net.Compilers.2.6.1\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Net.Compilers.2.6.1\build\Microsoft.Net.Compilers.props'))" />
     <Error Condition="!Exists('packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.8\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.8\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
+    <Error Condition="!Exists('packages\EntityFramework.6.4.4\build\EntityFramework.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\EntityFramework.6.4.4\build\EntityFramework.props'))" />
+    <Error Condition="!Exists('packages\EntityFramework.6.4.4\build\EntityFramework.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\EntityFramework.6.4.4\build\EntityFramework.targets'))" />
   </Target>
+  <Import Project="packages\EntityFramework.6.4.4\build\EntityFramework.targets" Condition="Exists('packages\EntityFramework.6.4.4\build\EntityFramework.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/dotnet/AspNetMvc5Ef6/Controllers/HomeController.cs
+++ b/dotnet/AspNetMvc5Ef6/Controllers/HomeController.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Web.Mvc;
 using AspNetMvc5Ef6.Models;
+using Sentry;
+using Sentry.Protocol;
 
 namespace AspNetMvc5Ef6.Controllers
 {
@@ -15,6 +17,13 @@ namespace AspNetMvc5Ef6.Controllers
         [HttpPost]
         public ActionResult PostIndex(string @params)
         {
+            SentrySdk.ConfigureScope(s =>
+            {
+                s.User = new User
+                {
+                    Username = "some-user"
+                };
+            });
             try
             {
                 if (@params == null)

--- a/dotnet/AspNetMvc5Ef6/Global.asax.cs
+++ b/dotnet/AspNetMvc5Ef6/Global.asax.cs
@@ -4,6 +4,8 @@ using Sentry.EntityFramework;
 using System.Configuration;
 using System.Web.Mvc;
 using System.Web.Routing;
+using Sentry.AspNet;
+using Sentry.Extensibility;
 
 namespace AspNetMvc5Ef6
 {
@@ -18,16 +20,20 @@ namespace AspNetMvc5Ef6
             RouteConfig.RegisterRoutes(RouteTable.Routes);
 
             // We add the query logging here so multiple DbContexts in the same project are supported
-            SentryDatabaseLogging.UseBreadcrumbs();
+            //SentryDatabaseLogging.UseBreadcrumbs();
 
             // Set up the sentry SDK
             _sentry = SentrySdk.Init(o =>
             {
                 // We store the DSN inside Web.config; make sure to use your own DSN!
-                o.Dsn = new Dsn(ConfigurationManager.AppSettings["SentryDsn"]);
+                o.Dsn = ConfigurationManager.AppSettings["SentryDsn"];
+
+                // To get ASP.NET Request information such as Headers
+                // and include Request Body of any size
+                o.AddAspNet(RequestSize.Always);
 
                 // Get Entity Framework integration
-                o.AddEntityFramework();
+                //o.AddEntityFramework();
             });
         }
 

--- a/dotnet/AspNetMvc5Ef6/Web.config
+++ b/dotnet/AspNetMvc5Ef6/Web.config
@@ -5,8 +5,8 @@
   -->
 <configuration>
   <configSections>
-    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
-    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+  <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+  <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
   </configSections>
   <connectionStrings>
     <add name="DefaultConnection" connectionString="Data Source=(LocalDb)\MSSQLLocalDB;AttachDbFilename=|DataDirectory|\aspnet-Sentry.Samples.AspNet.Mvc-20180711012610.mdf;Initial Catalog=aspnet-Sentry.Samples.AspNet.Mvc-20180711012610;Integrated Security=True" providerName="System.Data.SqlClient" />
@@ -17,7 +17,7 @@
     <add key="ClientValidationEnabled" value="true" />
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
     <!-- Sentry DSN, replace this with your own -->
-    <add key="SentryDsn" value="https://5fd7a6cda8444965bade9ccfd3df9882@sentry.io/1188141" />
+    <add key="SentryDsn" value="https://80aed643f81249d4bed3e30687b310ab@o447951.ingest.sentry.io/5428537" />
   </appSettings>
   <system.web>
     <authentication mode="None" />
@@ -89,6 +89,18 @@
       <dependentAssembly>
         <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Sentry" publicKeyToken="fba2ec45388e2af0" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Sentry.Protocol" publicKeyToken="fba2ec45388e2af0" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.0.2.0" newVersion="1.0.2.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/dotnet/AspNetMvc5Ef6/packages.config
+++ b/dotnet/AspNetMvc5Ef6/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Antlr" version="3.5.0.2" targetFramework="net462" />
   <package id="bootstrap" version="3.4.1" targetFramework="net462" />
-  <package id="EntityFramework" version="6.2.0" targetFramework="net462" />
+  <package id="EntityFramework" version="6.4.4" targetFramework="net462" />
   <package id="jQuery" version="3.3.1" targetFramework="net462" />
   <package id="jQuery.Validation" version="1.17.0" targetFramework="net462" />
   <package id="Microsoft.AspNet.Identity.Core" version="2.2.1" targetFramework="net462" />
@@ -13,6 +13,7 @@
   <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.0" targetFramework="net462" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net462" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.4" targetFramework="net462" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" targetFramework="net462" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.8" targetFramework="net462" />
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.2.4" targetFramework="net462" />
   <package id="Microsoft.Net.Compilers" version="2.6.1" targetFramework="net462" developmentDependency="true" />
@@ -29,13 +30,19 @@
   <package id="Modernizr" version="2.8.3" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net462" />
   <package id="Owin" version="1.0" targetFramework="net462" />
-  <package id="Sentry" version="1.1.0" targetFramework="net462" />
-  <package id="Sentry.EntityFramework" version="1.0.0" targetFramework="net462" />
-  <package id="Sentry.PlatformAbstractions" version="1.0.0" targetFramework="net462" />
-  <package id="Sentry.Protocol" version="1.0.2" targetFramework="net462" />
+  <package id="Sentry" version="3.0.0-alpha.7" targetFramework="net462" />
+  <package id="Sentry.AspNet" version="3.0.0-alpha.7" targetFramework="net462" />
+  <package id="Sentry.EntityFramework" version="2.1.6" targetFramework="net462" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net462" />
   <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net462" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.4.1" targetFramework="net462" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net462" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net462" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net462" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net462" />
+  <package id="System.Text.Encodings.Web" version="5.0.0" targetFramework="net462" />
+  <package id="System.Text.Json" version="5.0.0" targetFramework="net462" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net462" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net462" />
   <package id="WebGrease" version="1.6.0" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
We need to release a new Sentry.EntityFramework on top of the new SDK before we can finish this.

https://github.com/getsentry/sentry-dotnet-ef