### PR TITLE
fix(tunneling/nextjs): Validate host and projectId

### DIFF
--- a/tunneling/nextjs/pages/api/tunnel.js
+++ b/tunneling/nextjs/pages/api/tunnel.js
@@ -1,28 +1,37 @@
-import { withSentry } from "@sentry/nextjs";
+import { withSentry, captureException } from "@sentry/nextjs";
 import axios from "axios";
 import * as url from "url";
 
+// Change host appropriately if you run your own Sentry instance.
+const sentryHost = "sentry.io";
+
+// Set knownProjectIds to an array with your Sentry project IDs which you
+// want to accept through this proxy.
+const knownProjectIds = [];
+
 async function handler(req, res) {
-  const envelope = req.body;
-  const pieces = envelope.split("\n");
-
-  if (!pieces[0]) {
-    return res.status(400).json({ status: "broken_envelope" });
-  }
-
-  const header = JSON.parse(pieces[0]);
-
-  if (header.dsn) {
+  try {
+    const envelope = req.body;
+    const pieces = envelope.split("\n");
+    
+    const header = JSON.parse(pieces[0]);
+    
     const { host, path } = url.parse(header.dsn);
+    if (host !== sentryHost) {
+      throw new Error(`invalid host: ${host}`);
+    }
+    
     const projectId = path.endsWith("/") ? path.slice(0, -1) : path;
-    const sentryApi = `https://${host}/api/${projectId}/envelope/`;
-
-    const response = await axios.post(sentryApi, envelope);
-
-    return res.status(200).json(response.data);
+    if (!knownProjectIds.includes(projectId)) {
+      throw new Error(`invalid project id: ${projectId}`);
+    }
+    
+    const url = `https://${sentryHost}/api/${projectId}/envelope/`;
+    return await axios.post(url, envelope);
+  } catch (e) {
+    captureException(e);
+    return res.status(400).json({ status: "invalid request" });
   }
-
-  res.status(400).json({ status: "missing_dsn" });
 }
 
 export default withSentry(handler);


### PR DESCRIPTION
Update example to stop reading the target host from request body.
Instead, use explicit host configuration.

Similarly, limit project ID to a set of known IDs.

To limit leaking information, return the same status in case of any error and report the error to Sentry.

See https://github.com/getsentry/sentry-docs/issues/3945