### PR TITLE
misc: Update tunnel examples to use modern DSNs/subdomains

### DIFF
--- a/tunneling/dotnet/Program.cs
+++ b/tunneling/dotnet/Program.cs
@@ -9,15 +9,16 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 
 var client = new HttpClient();
-WebHost.CreateDefaultBuilder(args).Configure(a => 
+WebHost.CreateDefaultBuilder(args).Configure(a =>
     a.Run(async context =>
     {
         context.Request.EnableBuffering();
         using var reader = new StreamReader(context.Request.Body);
         var header = await reader.ReadLineAsync();
-        var allowedHosts = new[] { "sentry.io" }; // If you self-host Sentry, add your own domain here to prevent forged attacks
+        // TODO: change this according your needs
+        var allowedHosts = new[] { "oXXXXXX.ingest.sentry.io" };
         var headerJson = JsonSerializer.Deserialize<Dictionary<string, object>>(header);
-        if (headerJson.TryGetValue("dsn", out var dsnString) 
+        if (headerJson.TryGetValue("dsn", out var dsnString)
             && Uri.TryCreate(dsnString.ToString(), UriKind.Absolute, out var dsn) && allowedHosts.Contains(dsn.Host))
         {
             var projectId = dsn.AbsolutePath.Trim('/');
@@ -52,5 +53,5 @@ public class MyController : Controller
         }
 
         return NotFound();
-    }   
+    }
 }

--- a/tunneling/python/README.md
+++ b/tunneling/python/README.md
@@ -1,15 +1,13 @@
-# Tunnel events through a python3 based flask app
+# Tunnel events through a Python Flask app
 
-This example shows how you can use it to proxy events to Sentry.
+This example shows how you can use [Flask](https://flask.palletsprojects.com) to proxy events to Sentry.
 
-It returns with [status code][1] `200` even if the request failed to prevent e.g. brute force guessing of allowed configuration options.
+The app always returns with status code `200`, even if the request to Sentry failed, to prevent brute force guessing of allowed configuration options.
 
 ## To run this example:
 
-1. Install requirements (preferably in some [venv][1]):  
+1. Install requirements (preferably in some [venv](https://docs.python.org/3/library/venv.html)):  
   `pip install -r requirements.txt`
 2. Adjust `sentry_host` and `known_project_ids` in the `app.py` to your needs
 3. Run the app with e.g.: `flask run`
 4. Send sentry event to `http://localhost:5000/bugs`, e.g. via the test html mentioned at [examples/tunneling](../README.md)
-
-[1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status

--- a/tunneling/python/app.py
+++ b/tunneling/python/app.py
@@ -6,8 +6,8 @@ import requests
 from flask_cors import CORS
 import logging
 
-# change this according your needs
-sentry_host = "sentry.io"
+# TODO: change this according your needs
+sentry_host = "oXXXXXX.ingest.sentry.io"
 known_project_ids = ["123456"]
 
 app = flask.Flask(__name__)
@@ -23,18 +23,18 @@ def bugs():
         dsn = urllib.parse.urlparse(header.get("dsn"))
 
         if dsn.hostname != sentry_host:
-            raise Exception("Invalid sentry host")
+            raise Exception(f"Invalid Sentry host: {dsn.hostname}")
 
         project_id = dsn.path.strip("/")
         if project_id not in known_project_ids:
-            raise Exception(f"Invalid project id: {project_id}")
+            raise Exception(f"Invalid Project ID: {project_id}")
 
         url = f"https://{sentry_host}/api/{project_id}/envelope/"
 
         requests.post(url=url, data=envelope)
     except Exception as e:
-        # handle exception in your prefered style,
-        # e.g. by logging or forwarding to sentry
+        # handle exception in your preferred style,
+        # e.g. by logging or forwarding to Sentry
         logging.exception(e)
 
     return {}


### PR DESCRIPTION
Sentry issues DSNs with host names like 'oXXXXXX.ingest.sentry.io', and while it might be obvious to some, others may struggle to get the examples working. So we mark all places that need editing with TODO.