### PR TITLE
Finish the response in nextjs tunnel example

### DIFF
--- a/tunneling/nextjs/pages/api/tunnel.js
+++ b/tunneling/nextjs/pages/api/tunnel.js
@@ -30,7 +30,7 @@ async function handler(req, res) {
       method: "POST",
       body: envelope,
     });
-    return response.json();
+    return res.status(200).json(await response.json());
   } catch (e) {
     captureException(e);
     return res.status(400).json({ status: "invalid request" });


### PR DESCRIPTION
If `res.status().json()` is not called in the `try{}` block the browser thinks that the request is never finished, and will not close the connection. This can eventually lead to the page becoming unresponsive due to the number of open/unfinished requests to  `/api/tunnel`. Explicitly ending the response by returning a status and body/json will allow the browser to finish the response.




<!-- Describe your PR here. -->
I was running into a strange case yesterday where my site became unresponsive after a few page navigations (regardless of browser, or sentryjs version) and eventually tracked it down to the number of open requests to `/api/tunnel` that I copied from this example. Ending the response fixed the issue. 
I'm not sure how this will affect a production/vercel environment as I was having this issue in development.


<!--

  The following applies to third-party contributors.
  Sentry employees and contractors can delete or ignore.

-->

----

By submitting this pull request, I confirm that Sentry can use, modify, copy, and redistribute this contribution, under Sentry's choice of terms.
