### PR TITLE
Corrected typo in the link to the MainActivity.

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -2,6 +2,6 @@
 
 This example is best run inside of Android Studio or IntelliJ.
 
-You must set your DSN in [AndroidManifest.xml](https://github.com/getsentry/examples/blob/master/android/app/src/main/AndroidManifest.xml). See [MainActivity.java](https://github.com/getsentry/examples/blob/master/android/app/src/main/java/io/sentry/sample/MainActivity.java) for examples of how Sentry can be used.
+You must set your DSN in [AndroidManifest.xml](https://github.com/getsentry/examples/blob/master/android/app/src/main/AndroidManifest.xml). See [MainActivity.java](https://github.com/getsentry/examples/blob/master/android/app/src/main/java/io/sentry/samples/MainActivity.java) for examples of how Sentry can be used.
 
 You must set your org, project and auth token in [sentry.properties](https://github.com/getsentry/examples/blob/master/android/sentry.properties).


### PR DESCRIPTION
As simple as it sounds. There's been a typo in the README for a while that led to a 404 error. 