### PR TITLE
Fix tunneling example for Express

### DIFF
--- a/tunneling/expressjs/index.js
+++ b/tunneling/expressjs/index.js
@@ -1,19 +1,19 @@
 const express = require("express");
 
-// Allow body up to 100 MB
+// Allow body up to 100 MB, regardless of Content-Type header
 const app = express();
-
+const envelopeParser = express.raw({limit: "100mb", type: () => true});
 
 //TODO: Change this to suit your needs
 const SENTRY_HOST = "oXXXXXX.ingest.sentry.io";
 const SENTRY_KNOWN_PROJECTS = ["123456"]
 
 //TODO: Put your routes here, make sure to keep the /bugs route at the end of your file
-app.post("/bugs", async (req, res) => {
+app.post("/bugs", envelopeParser, async (req, res) => {
     try {
         const envelope = req.body;
 
-        const piece = envelope.toString().split("\n")[0];
+        const piece = envelope.slice(0, envelope.indexOf("\n"));
         const header = JSON.parse(piece);
 
         const dsn = new URL(header.dsn);

--- a/tunneling/expressjs/package.json
+++ b/tunneling/expressjs/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "fastify-sentry-tunneling",
+    "name": "express-sentry-tunneling",
     "version": "1.0.0",
-    "description": "Example to tunnel sentry using fastify",
+    "description": "Example to tunnel sentry using expressjs",
     "author": "",
     "main": "index.js",
     "dependencies": {


### PR DESCRIPTION
The tunneling example for Express.js that was published a week ago via PR #211 does not properly handle binary compressed session replay events. This PR rectifies that and changes references to fastify in the package.json for this example.

This PR properly fixes https://github.com/getsentry/sentry-javascript/issues/9047 and https://github.com/getsentry/sentry/issues/57793 (and a few other relating issues that probably don't need to be mentioned here).